### PR TITLE
Change consume to observe

### DIFF
--- a/reactor-groovy/src/main/groovy/reactor/groovy/ext/StreamExtensions.groovy
+++ b/reactor-groovy/src/main/groovy/reactor/groovy/ext/StreamExtensions.groovy
@@ -102,7 +102,7 @@ class StreamExtensions {
   }
 
   static <T> void rightShift(final Stream<T> selfType, final List<T> other) {
-    selfType.consume { other.add(it) }
+    selfType.observe { other.add(it) }
     Streams.await(selfType)
   }
 


### PR DESCRIPTION
Consume will cause some problems with Processors that don't allow multisubscribe since an await is directly after the consume step.